### PR TITLE
I5961 prevent directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,25 @@
+---
+name: Issue Template
+about: 'Generic template providing a baseline for any kind of issue'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Summary or User Story
+
+
+
+### Acceptance Criteria
+
+This section can be completed by the OPS team. Some requirements to consider
+including:
+
+- [ ] The UI implemented for this issue meets accessibility requirements
+- [ ] New functionality is documented
+
+
+### First step
+
+This section can be completed by the OPS team

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
-          image-ref: 'ghcr.io/pulibrary/pcdm.org:${{ steps.meta.outputs.version }}'
+          image-ref: 'ghcr.io/pulibrarymilberg:${{ steps.meta.outputs.version }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,149 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile
+  container-vuln-scan:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    if:
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.20.0
+        id: runscanner
+        continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+        with:
+          image-ref: 'ghcr.io/pulibrary/pcdm.org:${{ steps.meta.outputs.version }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          output: 'vulnerabilities.table'
+      - name: Set variables
+        id: scanner
+        if: ${{ always() }}
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "results<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat vulnerabilities.table)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Output variable
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SCANNER_OUTPUTS: ${{ steps.scanner.outputs.results }}
+        run: echo "${{ env.SCANNER_OUTPUTS }}"
+      - name: Find Comment for scan
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Container Scanning Status: '
+      - name: Create or update comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        env:
+          SCANNER_OUTPUTS: ${{ steps.scanner.outputs.results }}
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Container Scanning Status: ${{ steps.runscanner.outcome != 'success' && '❌ Failure' || '✅ Success' }}
+            ```
+            ${{ env.SCANNER_OUTPUTS }}
+            ```
+          edit-mode: replace
+      - name: Create issue
+        if: steps.runscanner.outcome != 'success' && github.event_name != 'pull_request'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SCANNER_OUTPUTS: ${{ steps.scanner.outputs.results }}
+        with:
+          filename: .github/failed-vuln-check.md
+          update_existing: true
+      - name: Find existing security issue
+        id: issues
+        if: steps.runscanner.outcome == 'success' && github.event_name != 'pull_request'
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          query: 'Container Vulnerability Scanner Failed is:open '
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close found issues
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.runscanner.outcome == 'success' && github.event_name != 'pull_request'
+        run: cat ${{ steps.issues.outputs.path }} | xargs gh issue close -c 'Container Scan Passing on Merge to Main'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
-          image-ref: 'ghcr.io/pulibrarymilberg:${{ steps.meta.outputs.version }}'
+          image-ref: 'ghcr.io/pulibrary/milberg_exhibit_archive:${{ steps.meta.outputs.version }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
-          image-ref: 'ghcr.io/pulibrarymilberg:main'
+          image-ref: 'ghcr.io/pulibrary/milberg_exhibit_archive:main'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -1,0 +1,70 @@
+name: Run nightly vulnerability check
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  container-vuln-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.20.0
+        id: runscanner
+        continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+        with:
+          image-ref: 'ghcr.io/pulibrary/pcdm.org:main'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          output: 'vulnerabilities.table'
+      - name: Set variables
+        id: scanner
+        if: job.steps.runscanner.status == failure()
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "results<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat vulnerabilities.table)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Output variable
+        if: job.steps.runscanner.status == failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SCANNER_OUTPUTS: ${{ steps.scanner.outputs.results }}
+        run: echo "${{ env.SCANNER_OUTPUTS }}"
+      - name: Create issue
+        if: steps.runscanner.outcome != 'success'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SCANNER_OUTPUTS: ${{ steps.scanner.outputs.results }}
+        with:
+          filename: .github/failed-vuln-check.md
+          update_existing: true
+      - name: Find existing security issue
+        id: issues
+        if: steps.runscanner.outcome == 'success'
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          query: 'Container Vulnerability Scanner Failed is:open '
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close found issues
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.runscanner.outcome == 'success'
+        run: cat ${{ steps.issues.outputs.path }} | xargs gh issue close -c 'Container Scan Passing on Merge to Main'

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
-          image-ref: 'ghcr.io/pulibrary/pcdm.org:main'
+          image-ref: 'ghcr.io/pulibrarymilberg:main'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Get the newest nginx
+FROM nginx:latest
+
+# Create the www directory within /usr/share/nginx/html
+RUN mkdir -p /usr/share/nginx/html/www
+
+# Copy the _site directory into the newly created www directory
+COPY . /usr/share/nginx/html/www
+
+# Copy the custom nginx configuration file
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# pcdm.org
+
+This is a static site of what was a Wordpress website of the milberg exhibit
+
+
+# Nginx Docker Container for Serving XML Files
+
+This project provides a Dockerized Nginx server configured to serve the milberg exhibit. It was formerly a wordpress site.
+
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Docker Compose](#docker-compose)
+- [File Structure](#file-structure)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Introduction
+
+This repository contains the necessary files to build and run a Docker container with Nginx serving the wordpress converted static site files. The project is designed to be flexible and easy to use, with a configurable server name and a custom Nginx configuration optimized for serving static content.
+
+## Prerequisites
+
+- Docker Engine and Docker Compose installed.  See the official Docker documentation for installation instructions: [https://docs.docker.com/](https://docs.docker.com/)
+- A directory containing your static files.
+- A custom Nginx configuration file (e.g., `default.conf`).
+
+## Installation
+
+1. Clone this repository (or copy the necessary files) to your local machine.
+2. Place your static files in the same directory as the `Dockerfile`.
+3. Ensure you have a `default.conf` file with your Nginx configuration in the same directory.  A sample configuration is provided below.
+
+## Usage
+
+1. **Build the Docker image:**
+
+   ```bash
+   docker build -t milberg .

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,59 @@
+#!/bin/bash
+ENV=$1
+BRANCH_NAME="${BRANCH:-main}"
+REPOSITORY="${REPO:-pcdm.org}"
+JOB_NAME="${JOBNAME:-pcdm.org}"
+
+# Make sure we're on VPN
+if ! nslookup nomad-host-prod1.lib.princeton.edu 2>&1 >/dev/null; then
+  echo "Unable to connect to nomad-host-prod1. Ensure you're on VPN."
+  exit 1
+fi
+
+## Get Github Token
+if ! command -v gh &>/dev/null; then
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "gh must be installed or a token passed with GITHUB_TOKEN. Run 'brew install gh'."
+    exit 1
+  fi
+fi
+
+GH_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}"
+
+if [ "$GH_TOKEN" = "" ]; then
+  echo "Github token not set. Run 'gh auth login' and follow the directions."
+  exit 1
+fi
+
+if [[ -z "${ENV}" ]]; then
+  echo "Missing Environment. Command: 'BRANCH=main ./bin/deploy staging'."
+  exit
+fi
+
+# Create Github Deployment
+DEPLOY_OUTPUT=$(curl -s -X POST -H "Accept: application/vnd.github+json-H" -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: Bearer ${GH_TOKEN}" --data "{\"ref\":\"${BRANCH_NAME}\",\"description\":\"Deploy from Nomad script\", \"auto_merge\": false, \"environment\": \"${ENV}\", \"required_contexts\": [] }" "https://api.github.com/repos/pulibrary/${REPOSITORY}/deployments")
+regex='"id": ([0-9]+),'
+[[ $DEPLOY_OUTPUT =~ $regex ]]
+DEPLOY_ID=${BASH_REMATCH[1]}
+
+if [[ -z "${DEPLOY_ID}" ]]; then
+  echo "Unable to fetch Deploy ID."
+  exit 1
+fi
+
+# Create "Started" Deployment Status
+curl -s -X POST -H "Accept: application/vnd.github+json-H" -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: Bearer ${GH_TOKEN}" --data "{\"environment\":\"${ENV}\",\"state\":\"in_progress\",\"log_url\": \"https://nomad.lib.princeton.edu/ui/jobs/${JOB_NAME}-${ENV}\", \"description\":\"Deployment started.\"}" "https://api.github.com/repos/pulibrary/${REPOSITORY}/deployments/${DEPLOY_ID}/statuses" >/dev/null
+
+# Deploy using nomad-host-prod1, which has the nomad management key.
+ssh deploy@nomad-host-prod1.lib.princeton.edu <<EOF
+  curl -H 'Cache-Control: no-cache' -s "https://raw.githubusercontent.com/pulibrary/${REPOSITORY}/${BRANCH_NAME}/${ENV}.hcl" | nomad job run -var "branch_or_sha=sha-$(git ls-remote https://github.com/pulibrary/${REPOSITORY}.git ${BRANCH_NAME} | awk '{ print substr($1,1,7) }')" -
+EOF
+retcode=$?
+
+if [ $retcode -eq 0 ]; then
+  # Create "Completed Successfully" Deployment Status
+  curl -s -X POST -H "Accept: application/vnd.github+json-H" -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: Bearer ${GH_TOKEN}" --data "{\"environment\":\"${ENV}\",\"state\":\"success\",\"log_url\": \"https://nomad.lib.princeton.edu/ui/jobs/${JOB_NAME}-${ENV}\", \"description\":\"Deployment finished successfully.\"}" "https://api.github.com/repos/pulibrary/${REPOSITORY}/deployments/${DEPLOY_ID}/statuses" >/dev/null
+else
+  # Create "Failed" Deployment Status
+  curl -s -X POST -H "Accept: application/vnd.github+json-H" -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: Bearer ${GH_TOKEN}" --data "{\"environment\":\"${ENV}\",\"state\":\"failure\",\"log_url\": \"https://nomad.lib.princeton.edu/ui/jobs/${JOB_NAME}-${ENV}\", \"description\":\"Deployment failed.\"}" "https://api.github.com/repos/pulibrary/${REPOSITORY}/deployments/${DEPLOY_ID}/statuses" >/dev/null
+fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,8 +1,8 @@
 #!/bin/bash
 ENV=$1
 BRANCH_NAME="${BRANCH:-main}"
-REPOSITORY="${REPO:-pcdm.org}"
-JOB_NAME="${JOBNAME:-pcdm.org}"
+REPOSITORY="${REPO:-milberg_exhibit_archive}"
+JOB_NAME="${JOBNAME:-milberg_exhibit_archive}"
 
 # Make sure we're on VPN
 if ! nslookup nomad-host-prod1.lib.princeton.edu 2>&1 >/dev/null; then

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name ${SERVER_NAME};
+    root /usr/share/nginx/html/www;
+    index index.html index.htm;
+
+    location / {
+        # Modified try_files to prevent redirection cycles
+        try_files $uri $uri/ $uri.html $uri.xml =404;
+    }
+
+    access_log /var/log/nginx/milberg-staging.access.log;
+    error_log /var/log/nginx/milberg-staging.error.log;
+}

--- a/default.conf
+++ b/default.conf
@@ -6,9 +6,9 @@ server {
 
     location / {
         # Modified try_files to prevent redirection cycles
-        try_files $uri $uri/ $uri.html $uri.xml =404;
+        try_files $uri $uri/ $uri.html =404;
     }
 
-    access_log /var/log/nginx/milberg-staging.access.log;
-    error_log /var/log/nginx/milberg-staging.error.log;
+    access_log /var/log/nginx/milberg.access.log;
+    error_log /var/log/nginx/milberg.error.log;
 }

--- a/default.conf
+++ b/default.conf
@@ -4,11 +4,6 @@ server {
     root /usr/share/nginx/html/www;
     index index.html index.htm;
 
-    location / {
-        # Modified try_files to prevent redirection cycles
-        try_files $uri $uri/ $uri.html =404;
-    }
-
     access_log /var/log/nginx/milberg.access.log;
     error_log /var/log/nginx/milberg.error.log;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: '3.9'
+services:
+  web:
+    build: .
+    ports: [80:80]
+    volumes: [./default.conf:/etc/nginx/conf.d/default.conf]
+    environment:
+      - SERVER_NAME=${SERVER_NAME:-milberg-staging.lib.princeton.edu}  # Default value if no env variable is set

--- a/production.hcl
+++ b/production.hcl
@@ -1,0 +1,27 @@
+variable "branch_or_sha" {
+  type = string
+  default = "main"
+}
+job "milberg-production" {
+  region = "global"
+  datacenters = ["dc1"]
+  node_pool = "production"
+  type = "service"
+  group "web" {
+    count = 2
+    network {
+      port "http" { to = 80 }
+    }
+    service {
+      port = "http"
+    }
+    task "webserver" {
+      driver = "podman"
+      config {
+        image = "ghcr.io/pulibrary/milberg_exhibit_archive:${ var.branch_or_sha }"
+        ports = ["http"]
+        force_pull = true
+      }
+    }
+  }
+}

--- a/staging.hcl
+++ b/staging.hcl
@@ -1,0 +1,27 @@
+variable "branch_or_sha" {
+  type = string
+  default = "main"
+}
+job "milberg-staging" {
+  region = "global"
+  datacenters = ["dc1"]
+  node_pool = "staging"
+  type = "service"
+  group "web" {
+    count = 2
+    network {
+      port "http" { to = 80 }
+    }
+    service {
+      port = "http"
+    }
+    task "webserver" {
+      driver = "podman"
+      config {
+        image = "ghcr.io/pulibrary/milberg:${ var.branch_or_sha }"
+        ports = ["http"]
+        force_pull = true
+      }
+    }
+  }
+}

--- a/staging.hcl
+++ b/staging.hcl
@@ -18,7 +18,7 @@ job "milberg-staging" {
     task "webserver" {
       driver = "podman"
       config {
-        image = "ghcr.io/pulibrary/milberg:${ var.branch_or_sha }"
+        image = "ghcr.io/pulibrary/milberg_exhibit_archive:${ var.branch_or_sha }"
         ports = ["http"]
         force_pull = true
       }


### PR DESCRIPTION
migrate milberg from static sites to use containers. Our static sites are exposing the .git directory of the repo they clone. We will take the opportunity to migrate the site to nomad. This work is related to this https://github.com/pulibrary/princeton_ansible/issues/5961